### PR TITLE
Get rid of unnecessary casting and make mixins work with abstract classes

### DIFF
--- a/src/lib/behaviors/behavior-interfaces.ts
+++ b/src/lib/behaviors/behavior-interfaces.ts
@@ -12,9 +12,6 @@ import {KeyScheme} from '../key_schemes/keyscheme';
 /** Constructor for a type T */
 export type Constructor<T = object> = new(...args: any[]) => T;
 
-/** Gets the inferred type of T */
-export type Inferred<T> = T extends infer I ? T | I : never;
-
 export interface HasLifecycle {
   setup(): void;
   teardown(): void;
@@ -27,7 +24,7 @@ export interface HasId {
 
 /** A control that has some number of items, such as a listbox or menu. */
 export interface HasItems<T> {
-  getItems(): Inferred<T>[];
+  getItems(): T[];
 }
 
 /** A control that can be oriented either veritcally or horizontally. */
@@ -37,7 +34,7 @@ export interface HasOrientation {
 
 /** A control that has some keyboard interaction. */
 export interface HasKeySchemes<C> {
-  getKeySchemes(): KeyScheme<Inferred<C>>[];
+  getKeySchemes(): KeyScheme<C>[];
 }
 
 /** A control whose interaction is affected by the locale text direction. */
@@ -69,7 +66,7 @@ export interface HasActiveDescendant<D> {
   activeDescendantId: string;
 
   activeDescendantIndex(): number;
-  activeDescendant(): Inferred<D>;
+  activeDescendant(): D;
 
   activateNextItem(): void;
   activatePreviousItem(): void;
@@ -82,7 +79,7 @@ export interface HasSelectedDescendant<D extends CanBeSelected> {
   multiple: boolean;
   selectedDescendantId: string;
 
-  selectItem(item: Inferred<D>): void;
-  deselectItem(item: Inferred<D>): void;
+  selectItem(item: D): void;
+  deselectItem(item: D): void;
   toggleActiveItemSelection(): void;
 }

--- a/src/lib/behaviors/behavior-interfaces.ts
+++ b/src/lib/behaviors/behavior-interfaces.ts
@@ -9,8 +9,14 @@
 import {KeyScheme} from '../key_schemes/keyscheme';
 
 
-/** Constructor for a type T */
-export type Constructor<T = object> = new(...args: any[]) => T;
+/** Concrete constructor for a type T */
+export type Constructor<T = object> = (new(...args: any[]) => T);
+
+/** Concrete or abstract constructor for a type T */
+export type ConcreteOrAbstractConstructor<T = object> = (Function & {prototype: T});
+
+/** Constructor for an abstract type T */
+//export type Constructor<T = object> = Function & {prototype: T};
 
 export interface HasLifecycle {
   setup(): void;

--- a/src/lib/behaviors/behavior-interfaces.ts
+++ b/src/lib/behaviors/behavior-interfaces.ts
@@ -12,6 +12,9 @@ import {KeyScheme} from '../key_schemes/keyscheme';
 /** Constructor for a type T */
 export type Constructor<T = object> = new(...args: any[]) => T;
 
+/** Gets the inferred type of T */
+export type Inferred<T> = T extends infer I ? T | I : never;
+
 export interface HasLifecycle {
   setup(): void;
   teardown(): void;
@@ -24,7 +27,7 @@ export interface HasId {
 
 /** A control that has some number of items, such as a listbox or menu. */
 export interface HasItems<T> {
-  getItems(): T[];
+  getItems(): Inferred<T>[];
 }
 
 /** A control that can be oriented either veritcally or horizontally. */
@@ -34,7 +37,7 @@ export interface HasOrientation {
 
 /** A control that has some keyboard interaction. */
 export interface HasKeySchemes<C> {
-  getKeySchemes(): KeyScheme<C>[];
+  getKeySchemes(): KeyScheme<Inferred<C>>[];
 }
 
 /** A control whose interaction is affected by the locale text direction. */
@@ -66,7 +69,7 @@ export interface HasActiveDescendant<D> {
   activeDescendantId: string;
 
   activeDescendantIndex(): number;
-  activeDescendant(): D;
+  activeDescendant(): Inferred<D>;
 
   activateNextItem(): void;
   activatePreviousItem(): void;
@@ -79,7 +82,7 @@ export interface HasSelectedDescendant<D extends CanBeSelected> {
   multiple: boolean;
   selectedDescendantId: string;
 
-  selectItem(item: D): void;
-  deselectItem(item: D): void;
+  selectItem(item: Inferred<D>): void;
+  deselectItem(item: Inferred<D>): void;
   toggleActiveItemSelection(): void;
 }

--- a/src/lib/behaviors/behavior-interfaces.ts
+++ b/src/lib/behaviors/behavior-interfaces.ts
@@ -9,14 +9,11 @@
 import {KeyScheme} from '../key_schemes/keyscheme';
 
 
-/** Concrete constructor for a type T */
-export type Constructor<T = object> = (new(...args: any[]) => T);
+/** Constructor for a concrete type T */
+export type Constructor<T = object> = new(...args: any[]) => T;
 
-/** Concrete or abstract constructor for a type T */
-export type ConcreteOrAbstractConstructor<T = object> = (Function & {prototype: T});
-
-/** Constructor for an abstract type T */
-//export type Constructor<T = object> = Function & {prototype: T};
+/** Constructor for a concrete or abstract type T */
+export type ConcreteOrAbstractConstructor<T = object> = Function & {prototype: T};
 
 export interface HasLifecycle {
   setup(): void;

--- a/src/lib/behaviors/behavior-mixins.ts
+++ b/src/lib/behaviors/behavior-mixins.ts
@@ -19,7 +19,6 @@ import {
   HasLifecycle,
   HasOrientation,
   HasSelectedDescendant,
-  Inferred,
 } from './behavior-interfaces';
 
 
@@ -98,12 +97,12 @@ export function mixinActiveDescendant<T extends Constructor<HasItems<D>>,
       return this.getItems().findIndex(i => i.id === this.activeDescendantId);
     }
 
-    activeDescendant(): Inferred<D> {
+    activeDescendant(): D {
       // TODO(mmalerba): Is it safe to assume this is always defined?
-      return this.getItems().find(i => i.id === this.activeDescendantId) as Inferred<D>;
+      return this.getItems().find(i => i.id === this.activeDescendantId) as D;
     }
 
-    activateItem(item: Inferred<D>) {
+    activateItem(item: D) {
       // No-op if the given item is disabled.
       if (!item.disabled) {
         this.activeDescendantId = item.id;
@@ -165,7 +164,7 @@ export function mixinSelectedDescendant<T extends Constructor<HasItems<D> & HasA
     multiple = false;
     selectedDescendantId = '';
 
-    selectItem(item: Inferred<D>) {
+    selectItem(item: D) {
       if (!this.multiple) {
         this.getItems().forEach(i => i.selected = false);
       }
@@ -173,7 +172,7 @@ export function mixinSelectedDescendant<T extends Constructor<HasItems<D> & HasA
       item.selected = true;
     }
 
-    deselectItem(item: Inferred<D>) {
+    deselectItem(item: D) {
       item.selected = false;
     }
 

--- a/src/lib/behaviors/behavior-mixins.ts
+++ b/src/lib/behaviors/behavior-mixins.ts
@@ -15,9 +15,11 @@ import {
   Constructor,
   HasActiveDescendant,
   HasId,
-  HasItems, HasLifecycle,
+  HasItems,
+  HasLifecycle,
   HasOrientation,
   HasSelectedDescendant,
+  Inferred,
 } from './behavior-interfaces';
 
 
@@ -75,11 +77,10 @@ export function mixinBidi<T extends Constructor>(base: T): Constructor<AffectedB
   }
 }
 
-
 /** Mixin that augments a given class with behavior for having an active descendant item. */
 export function mixinActiveDescendant<T extends Constructor<HasItems<D>>,
     D extends HasId & CanBeDisabled>(base: T):
-        Constructor<HasActiveDescendant<T extends Constructor<HasItems<infer I>> ? I : any>> & T {
+        Constructor<HasActiveDescendant<D>> & T {
   return class extends base implements HasActiveDescendant<D> {
     activeDescendantId = '';
 
@@ -97,12 +98,12 @@ export function mixinActiveDescendant<T extends Constructor<HasItems<D>>,
       return this.getItems().findIndex(i => i.id === this.activeDescendantId);
     }
 
-    activeDescendant(): D {
+    activeDescendant(): Inferred<D> {
       // TODO(mmalerba): Is it safe to assume this is always defined?
-      return this.getItems().find(i => i.id === this.activeDescendantId)!;
+      return this.getItems().find(i => i.id === this.activeDescendantId) as Inferred<D>;
     }
 
-    activateItem(item: D) {
+    activateItem(item: Inferred<D>) {
       // No-op if the given item is disabled.
       if (!item.disabled) {
         this.activeDescendantId = item.id;
@@ -153,18 +154,18 @@ export function mixinActiveDescendant<T extends Constructor<HasItems<D>>,
     }
 
     constructor(...args: any[]) { super(...args); }
-  } as Constructor<HasActiveDescendant<any>> & T;
+  };
 }
 
 /** Mixin that augments a given class with behavior for descendant items than can be selected. */
 export function mixinSelectedDescendant<T extends Constructor<HasItems<D> & HasActiveDescendant<D>>,
     D extends HasId & CanBeDisabled & CanBeSelected>(base: T):
-    Constructor<HasSelectedDescendant<T extends Constructor<HasItems<infer I>> ? I : any>> & T {
+    Constructor<HasSelectedDescendant<D>> & T {
   return class extends base implements HasSelectedDescendant<D> {
     multiple = false;
     selectedDescendantId = '';
 
-    selectItem(item: D) {
+    selectItem(item: Inferred<D>) {
       if (!this.multiple) {
         this.getItems().forEach(i => i.selected = false);
       }
@@ -172,7 +173,7 @@ export function mixinSelectedDescendant<T extends Constructor<HasItems<D> & HasA
       item.selected = true;
     }
 
-    deselectItem(item: D) {
+    deselectItem(item: Inferred<D>) {
       item.selected = false;
     }
 

--- a/src/lib/behaviors/behavior-mixins.ts
+++ b/src/lib/behaviors/behavior-mixins.ts
@@ -12,6 +12,7 @@ import {
   AffectedByRtl,
   CanBeDisabled,
   CanBeSelected,
+  ConcreteOrAbstractConstructor,
   Constructor,
   HasActiveDescendant,
   HasId,
@@ -21,6 +22,15 @@ import {
   HasSelectedDescendant,
 } from './behavior-interfaces';
 
+
+/** Function used to create base class passed to mixins. */
+export function createMixinBase<B extends ConcreteOrAbstractConstructor, S extends object = object>(
+    base?: B | undefined): B & Constructor<S> {
+  // TypeScript doesn't allow abstract classes to be extended via a mixin, so we need to tell typescript that this is a
+  // `Constructor`. We also may need to specify an abstract stub type so that TypeScript knows which methods need to be
+  // filled in by the user.
+  return (base || class {}) as B & Constructor<S>;
+}
 
 /** Mixin that augments a given class with a `disabled` property. */
 export function mixinDisabled<T extends Constructor>(base: T): Constructor<CanBeDisabled> & T {
@@ -99,7 +109,7 @@ export function mixinActiveDescendant<T extends Constructor<HasItems<D>>,
 
     activeDescendant(): D {
       // TODO(mmalerba): Is it safe to assume this is always defined?
-      return this.getItems().find(i => i.id === this.activeDescendantId) as D;
+      return this.getItems().find(i => i.id === this.activeDescendantId)!;
     }
 
     activateItem(item: D) {

--- a/src/lib/dom_impl/listbox.ts
+++ b/src/lib/dom_impl/listbox.ts
@@ -83,3 +83,28 @@ export class OptionDom extends mixinOption() {
     this.hostElement.setAttribute('role', 'option');
   }
 }
+
+
+abstract class AbstractDummy {
+  abstract dumb(): void;
+}
+
+abstract class AbstractDummyListbox extends mixinDomKeyHandling(mixinDomFocus(mixinListbox(AbstractDummy))) {
+  constructor(public hostElement: HTMLElement) {super();}
+  getItems(): OptionPattern[] {return [];}
+  render() {this.dumb();}
+}
+
+class ConcreteAbstractDummyListbox extends AbstractDummyListbox {
+  dumb() {}
+}
+
+class ConcreteDummy {
+  dumb() {}
+}
+
+class ConcreteDummyListbox extends mixinDomKeyHandling(mixinDomFocus(mixinListbox(ConcreteDummy))) {
+  constructor(public hostElement: HTMLElement) {super();}
+  getItems(): OptionPattern[] {return [];}
+  render() {this.dumb();}
+}

--- a/src/lib/key_schemes/keyscheme.ts
+++ b/src/lib/key_schemes/keyscheme.ts
@@ -7,6 +7,8 @@
  */
 
 
+import {Inferred} from '../behaviors/behavior-interfaces';
+
 /**
  * Represents a set of keyboard controls that map to actions. One or more KeySchemes can
  * be applied to a control.
@@ -21,5 +23,5 @@ export interface KeyScheme<T> {
    * @param keyEvent The keyboard event being handled.
    * @returns Whether the key event has handled by this scheme.
    */
-  handleKey(control: T, keyEvent: KeyboardEvent): boolean;
+  handleKey(control: Inferred<T>, keyEvent: KeyboardEvent): boolean;
 }

--- a/src/lib/key_schemes/keyscheme.ts
+++ b/src/lib/key_schemes/keyscheme.ts
@@ -7,8 +7,6 @@
  */
 
 
-import {Inferred} from '../behaviors/behavior-interfaces';
-
 /**
  * Represents a set of keyboard controls that map to actions. One or more KeySchemes can
  * be applied to a control.
@@ -23,5 +21,5 @@ export interface KeyScheme<T> {
    * @param keyEvent The keyboard event being handled.
    * @returns Whether the key event has handled by this scheme.
    */
-  handleKey(control: Inferred<T>, keyEvent: KeyboardEvent): boolean;
+  handleKey(control: T, keyEvent: KeyboardEvent): boolean;
 }

--- a/src/lib/key_schemes/list-navigation.ts
+++ b/src/lib/key_schemes/list-navigation.ts
@@ -6,19 +6,19 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {AffectedByRtl, HasActiveDescendant, HasOrientation} from '../behaviors/behavior-interfaces';
+import {AffectedByRtl, HasActiveDescendant, HasOrientation, Inferred} from '../behaviors/behavior-interfaces';
 import {DOWN_ARROW, LEFT_ARROW, RIGHT_ARROW, UP_ARROW} from './keycodes';
 import {KeyScheme} from './keyscheme';
 
 
 /** A list-like control that has arrow-key navigation, such as listbox or menu. */
-export type ListLike = HasActiveDescendant<any> & AffectedByRtl & HasOrientation;
+export type ListLike<D> = HasActiveDescendant<D> & AffectedByRtl & HasOrientation;
 
 // TODO: KeySchemes can be singletons
 
 /** Key scheme for navigating through a list-like control, such as a listbox or menu. */
-export class ListNavigationKeyScheme implements KeyScheme<ListLike> {
-  handleKey(control: ListLike, event: KeyboardEvent): boolean {
+export class ListNavigationKeyScheme implements KeyScheme<ListLike<{}>> {
+  handleKey(control: Inferred<ListLike<{}>>, event: KeyboardEvent): boolean {
     const keyCode = event.keyCode;
 
     switch (keyCode) {

--- a/src/lib/key_schemes/list-navigation.ts
+++ b/src/lib/key_schemes/list-navigation.ts
@@ -6,19 +6,19 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {AffectedByRtl, HasActiveDescendant, HasOrientation, Inferred} from '../behaviors/behavior-interfaces';
+import {AffectedByRtl, HasActiveDescendant, HasOrientation} from '../behaviors/behavior-interfaces';
 import {DOWN_ARROW, LEFT_ARROW, RIGHT_ARROW, UP_ARROW} from './keycodes';
 import {KeyScheme} from './keyscheme';
 
 
 /** A list-like control that has arrow-key navigation, such as listbox or menu. */
-export type ListLike<D> = HasActiveDescendant<D> & AffectedByRtl & HasOrientation;
+export type ListLike<D = {}> = HasActiveDescendant<D> & AffectedByRtl & HasOrientation;
 
 // TODO: KeySchemes can be singletons
 
 /** Key scheme for navigating through a list-like control, such as a listbox or menu. */
-export class ListNavigationKeyScheme implements KeyScheme<ListLike<{}>> {
-  handleKey(control: Inferred<ListLike<{}>>, event: KeyboardEvent): boolean {
+export class ListNavigationKeyScheme implements KeyScheme<ListLike> {
+  handleKey(control: ListLike, event: KeyboardEvent): boolean {
     const keyCode = event.keyCode;
 
     switch (keyCode) {

--- a/src/lib/key_schemes/list-navigation.ts
+++ b/src/lib/key_schemes/list-navigation.ts
@@ -12,7 +12,7 @@ import {KeyScheme} from './keyscheme';
 
 
 /** A list-like control that has arrow-key navigation, such as listbox or menu. */
-export type ListLike<D = {}> = HasActiveDescendant<D> & AffectedByRtl & HasOrientation;
+export type ListLike<D = unknown> = HasActiveDescendant<D> & AffectedByRtl & HasOrientation;
 
 // TODO: KeySchemes can be singletons
 

--- a/src/lib/patterns/listbox.ts
+++ b/src/lib/patterns/listbox.ts
@@ -19,6 +19,7 @@ import {
   HasSelectedDescendant,
 } from '../behaviors/behavior-interfaces';
 import {
+  createMixinBase,
   mixinActiveDescendant,
   mixinBidi,
   mixinDisabled, mixinLifecycle,
@@ -65,13 +66,7 @@ export interface ListboxPattern extends
     HasActiveDescendant<OptionPattern>,
     HasSelectedDescendant<OptionPattern> { }
 
-// Note: the `as Constructor<ListboxStub>` cast below exists to enforce that downstream classes that
-// apply this mixin are still required to implement any abstract members on the stub class.
-// The casts for `as Constructor<ListboxPattern> & T` and `as any` exist because the precense of the
-// abstract stub class prevents TypeScript from recognizing that the mixins applied satisfy the
-// structure of `ListboxPattern`.
-
-export function mixinListboxKeyScheme<T extends Constructor>(base: T):
+function mixinListboxKeyScheme<T extends Constructor>(base: T):
     Constructor<HasKeySchemes<ListboxPattern>> & T {
   return class extends base implements HasKeySchemes<ListboxPattern> {
     getKeySchemes(): KeyScheme<ListboxPattern>[] {
@@ -92,5 +87,6 @@ export function mixinListbox<T extends ConcreteOrAbstractConstructor>(base?: T):
     mixinOrientation(
     mixinLifecycle(
     mixinDisabled(
-    mixinUniqueId((base || class {}) as T & Constructor<ListboxStub>))))))));
+    mixinUniqueId(
+    createMixinBase<T, ListboxStub>(base)))))))));
 }

--- a/src/lib/patterns/listbox.ts
+++ b/src/lib/patterns/listbox.ts
@@ -70,21 +70,24 @@ export interface ListboxPattern extends
 // abstract stub class prevents TypeScript from recognizing that the mixins applied satisfy the
 // structure of `ListboxPattern`.
 
+export function mixinListboxKeyScheme<T extends Constructor>(base: T): Constructor<HasKeySchemes<ListboxPattern>> & T {
+  return class extends base implements HasKeySchemes<ListboxPattern> {
+    getKeySchemes(): KeyScheme<ListboxPattern>[] {
+      return listboxKeySchemes;
+    }
+
+    constructor(...args: any[]) { super(...args); }
+  };
+}
+
 /** Mixes the common behaviors of a ListBox onto a class */
 export function mixinListbox<T extends Constructor>(base?: T): Constructor<ListboxPattern> & T {
-  return class extends (
+  return mixinListboxKeyScheme(
     mixinSelectedDescendant(
     mixinActiveDescendant(
     mixinBidi(
     mixinOrientation(
     mixinLifecycle(
     mixinDisabled(
-    mixinUniqueId((base || class { }) as Constructor<ListboxStub>))))))) as any) {
-
-    getKeySchemes(): KeyScheme<ListboxPattern>[] {
-      return listboxKeySchemes;
-    }
-
-    constructor(...args: any[]) { super(...args); }
-  } as Constructor<ListboxPattern> & T;
+    mixinUniqueId((base || class {}) as T & Constructor<ListboxStub>))))))));
 }

--- a/src/lib/patterns/listbox.ts
+++ b/src/lib/patterns/listbox.ts
@@ -6,6 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 import {
+  ConcreteOrAbstractConstructor,
   AffectedByRtl,
   CanBeDisabled,
   CanBeFocused,
@@ -70,7 +71,8 @@ export interface ListboxPattern extends
 // abstract stub class prevents TypeScript from recognizing that the mixins applied satisfy the
 // structure of `ListboxPattern`.
 
-export function mixinListboxKeyScheme<T extends Constructor>(base: T): Constructor<HasKeySchemes<ListboxPattern>> & T {
+export function mixinListboxKeyScheme<T extends Constructor>(base: T):
+    Constructor<HasKeySchemes<ListboxPattern>> & T {
   return class extends base implements HasKeySchemes<ListboxPattern> {
     getKeySchemes(): KeyScheme<ListboxPattern>[] {
       return listboxKeySchemes;
@@ -81,7 +83,8 @@ export function mixinListboxKeyScheme<T extends Constructor>(base: T): Construct
 }
 
 /** Mixes the common behaviors of a ListBox onto a class */
-export function mixinListbox<T extends Constructor>(base?: T): Constructor<ListboxPattern> & T {
+export function mixinListbox<T extends ConcreteOrAbstractConstructor>(base?: T):
+    Constructor<ListboxPattern> & T {
   return mixinListboxKeyScheme(
     mixinSelectedDescendant(
     mixinActiveDescendant(

--- a/src/lib/patterns/listbox.ts
+++ b/src/lib/patterns/listbox.ts
@@ -71,8 +71,7 @@ export interface ListboxPattern extends
 // structure of `ListboxPattern`.
 
 /** Mixes the common behaviors of a ListBox onto a class */
-export function mixinListbox<T extends Constructor<object>>(base?: T):
-    Constructor<ListboxPattern> & T {
+export function mixinListbox<T extends Constructor>(base?: T): Constructor<ListboxPattern> & T {
   return class extends (
     mixinSelectedDescendant(
     mixinActiveDescendant(

--- a/src/lib/patterns/menu.ts
+++ b/src/lib/patterns/menu.ts
@@ -9,17 +9,21 @@ import {
   AffectedByRtl,
   CanBeDisabled,
   CanBeFocused,
+  ConcreteOrAbstractConstructor,
   Constructor,
   HasActiveDescendant,
   HasId,
   HasItems,
-  HasKeySchemes, HasLifecycle,
+  HasKeySchemes,
+  HasLifecycle,
   HasOrientation,
 } from '../behaviors/behavior-interfaces';
 import {
+  createMixinBase,
   mixinActiveDescendant,
   mixinBidi,
-  mixinDisabled, mixinLifecycle,
+  mixinDisabled,
+  mixinLifecycle,
   mixinOrientation,
   mixinUniqueId,
 } from '../behaviors/behavior-mixins';
@@ -62,26 +66,24 @@ export interface MenuPattern extends
     HasKeySchemes<MenuPattern>,
     HasActiveDescendant<MenuItemPattern> { }
 
-// Note: the `as Constructor<MenuStub>` cast below exists to enforce that downstream classes that
-// apply this mixin are still required to implement any abstract members on the stub class.
-// The casts for `as Constructor<MenuPattern> & T` and `as any` exist because the precense of the
-// abstract stub class prevents TypeScript from recognizing that the mixins applied satisfy the
-// structure of `MenuPattern`.
-
-/** Mixes the common behaviors of a menu onto a class */
-export function mixinMenu<T extends Constructor>(base?: T): Constructor<MenuPattern> & T {
-  return class extends (
-    mixinActiveDescendant(
-    mixinBidi(
-    mixinOrientation(
-    mixinLifecycle(
-    mixinDisabled(
-    mixinUniqueId((base || class { }) as Constructor<MenuStub>)))))) as any) {
-
+function mixinMenuKeyScheme<T extends Constructor>(base: T): Constructor<HasKeySchemes<MenuPattern>> & T {
+  return class extends base implements HasKeySchemes<MenuPattern> {
     getKeySchemes(): KeyScheme<MenuPattern>[] {
       return menuKeySchemes;
     }
 
     constructor(...args: any[]) { super(...args); }
-  } as Constructor<MenuPattern> & T;
+  }
+}
+
+/** Mixes the common behaviors of a menu onto a class */
+export function mixinMenu<T extends ConcreteOrAbstractConstructor>(base?: T): Constructor<MenuPattern> & T {
+  return mixinMenuKeyScheme(
+    mixinActiveDescendant(
+    mixinBidi(
+    mixinOrientation(
+    mixinLifecycle(
+    mixinDisabled(
+    mixinUniqueId(
+    createMixinBase<T, MenuStub>(base))))))));
 }

--- a/src/lib/patterns/menu.ts
+++ b/src/lib/patterns/menu.ts
@@ -69,7 +69,7 @@ export interface MenuPattern extends
 // structure of `MenuPattern`.
 
 /** Mixes the common behaviors of a menu onto a class */
-export function mixinMenu<T extends Constructor<object>>(base?: T): Constructor<MenuPattern> & T {
+export function mixinMenu<T extends Constructor>(base?: T): Constructor<MenuPattern> & T {
   return class extends (
     mixinActiveDescendant(
     mixinBidi(

--- a/src/lib/patterns/menuitem.ts
+++ b/src/lib/patterns/menuitem.ts
@@ -5,8 +5,14 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
-import {CanBeDisabled, Constructor, HasId, HasLifecycle} from '../behaviors/behavior-interfaces';
-import {mixinDisabled, mixinLifecycle, mixinUniqueId} from '../behaviors/behavior-mixins';
+import {
+  CanBeDisabled,
+  ConcreteOrAbstractConstructor,
+  Constructor,
+  HasId,
+  HasLifecycle
+} from '../behaviors/behavior-interfaces';
+import {createMixinBase, mixinDisabled, mixinLifecycle, mixinUniqueId} from '../behaviors/behavior-mixins';
 
 
 /** Abstract stub for base `menuitem` behavior that must be implemented by the end-developer. */
@@ -15,18 +21,10 @@ declare abstract class MenuItemStub { }
 /** Union of all behaviors that compose into an `menuitem`. */
 export interface MenuItemPattern extends HasLifecycle, CanBeDisabled, HasId { }
 
-// Note: the `as Constructor<MenuItemStub>` cast below exists to enforce that downstream classes
-// that apply this mixin are still required to implement any abstract members on the stub class.
-// The casts for `as Constructor<MenuItemPattern> & T` and `as any` exist because the precense of
-// the abstract stub class prevents TypeScript from recognizing that the mixins applied satisfy the
-// structure of `MenuItemPattern`.
-
 /** Mixin that augments the given class with the behaviors for an `menuitem`. */
-export function mixinMenuItem<T extends Constructor>(base?: T): Constructor<MenuItemPattern> & T {
-  return class extends (
-    mixinUniqueId(
+export function mixinMenuItem<T extends ConcreteOrAbstractConstructor>(base?: T): Constructor<MenuItemPattern> & T {
+  return mixinUniqueId(
     mixinLifecycle(
-    mixinDisabled((base || class { } as Constructor<MenuItemStub>)))) as any) {
-    constructor(...args: any[]) { super(...args); }
-  } as Constructor<MenuItemPattern> & T;
+    mixinDisabled(
+    createMixinBase<T, MenuItemStub>(base))));
 }

--- a/src/lib/patterns/menuitem.ts
+++ b/src/lib/patterns/menuitem.ts
@@ -22,7 +22,7 @@ export interface MenuItemPattern extends HasLifecycle, CanBeDisabled, HasId { }
 // structure of `MenuItemPattern`.
 
 /** Mixin that augments the given class with the behaviors for an `menuitem`. */
-export function mixinMenuItem<T extends Constructor<object>>(base?: T): Constructor<MenuItemPattern> & T {
+export function mixinMenuItem<T extends Constructor>(base?: T): Constructor<MenuItemPattern> & T {
   return class extends (
     mixinUniqueId(
     mixinLifecycle(

--- a/src/lib/patterns/option.ts
+++ b/src/lib/patterns/option.ts
@@ -34,11 +34,8 @@ export interface OptionPattern extends HasLifecycle, CanBeDisabled, HasId, CanBe
 
 /** Mixin that augments the given class with the behaviors for an `option`. */
 export function mixinOption<T extends Constructor>(base?: T): Constructor<OptionPattern> & T {
-  return class extends (
-    mixinSelected(
+  return mixinSelected(
     mixinUniqueId(
     mixinLifecycle(
-    mixinDisabled((base || class { } as Constructor<OptionStub>))))) as any) {
-    constructor(...args: any[]) { super(...args); }
-  } as Constructor<OptionPattern> & T;
+    mixinDisabled((base || class {} as T & Constructor<OptionStub>)))));
 }

--- a/src/lib/patterns/option.ts
+++ b/src/lib/patterns/option.ts
@@ -8,11 +8,13 @@
 import {
   CanBeDisabled,
   CanBeSelected,
+  ConcreteOrAbstractConstructor,
   Constructor,
   HasId,
   HasLifecycle,
 } from '../behaviors/behavior-interfaces';
 import {
+  createMixinBase,
   mixinDisabled,
   mixinLifecycle,
   mixinSelected,
@@ -26,16 +28,11 @@ declare abstract class OptionStub { }
 /** Union of all behaviors that compose into an `option`. */
 export interface OptionPattern extends HasLifecycle, CanBeDisabled, HasId, CanBeSelected { }
 
-// Note: the `as Constructor<OptionStub>` cast below exists to enforce that downstream classes that
-// apply this mixin are still required to implement any abstract members on the stub class.
-// The casts for `as Constructor<OptionPattern> & T` and `as any` exist because the precense of the
-// abstract stub class prevents TypeScript from recognizing that the mixins applied satisfy the
-// structure of `OptionPattern`.
-
 /** Mixin that augments the given class with the behaviors for an `option`. */
-export function mixinOption<T extends Constructor>(base?: T): Constructor<OptionPattern> & T {
+export function mixinOption<T extends ConcreteOrAbstractConstructor>(base?: T): Constructor<OptionPattern> & T {
   return mixinSelected(
     mixinUniqueId(
     mixinLifecycle(
-    mixinDisabled((base || class {} as T & Constructor<OptionStub>)))));
+    mixinDisabled(
+    createMixinBase<T, OptionStub>(base)))));
 }

--- a/src/lib/patterns/option.ts
+++ b/src/lib/patterns/option.ts
@@ -33,7 +33,7 @@ export interface OptionPattern extends HasLifecycle, CanBeDisabled, HasId, CanBe
 // structure of `OptionPattern`.
 
 /** Mixin that augments the given class with the behaviors for an `option`. */
-export function mixinOption<T extends Constructor<object>>(base?: T): Constructor<OptionPattern> & T {
+export function mixinOption<T extends Constructor>(base?: T): Constructor<OptionPattern> & T {
   return class extends (
     mixinSelected(
     mixinUniqueId(

--- a/src/lib/patterns/tab.ts
+++ b/src/lib/patterns/tab.ts
@@ -8,11 +8,13 @@
 import {
   CanBeDisabled,
   CanBeSelected,
+  ConcreteOrAbstractConstructor,
   Constructor,
   HasId,
   HasLifecycle,
 } from '../behaviors/behavior-interfaces';
 import {
+  createMixinBase,
   mixinDisabled,
   mixinLifecycle,
   mixinSelected,
@@ -26,19 +28,11 @@ declare abstract class TabStub { }
 /** Union of all behaviors that compose into an `tab`. */
 export interface TabPattern extends HasLifecycle, CanBeDisabled, HasId, CanBeSelected { }
 
-// Note: the `as Constructor<TabStub>` cast below exists to enforce that downstream classes that
-// apply this mixin are still required to implement any abstract members on the stub class.
-// The casts for `as Constructor<TabPattern> & T` and `as any` exist because the precense of the
-// abstract stub class prevents TypeScript from recognizing that the mixins applied satisfy the
-// structure of `TabPattern`.
-
 /** Mixin that augments the given class with the behaviors for an `tab`. */
-export function mixinTab<T extends Constructor>(base?: T): Constructor<TabPattern> & T {
-  return class extends (
-    mixinSelected(
+export function mixinTab<T extends ConcreteOrAbstractConstructor>(base?: T): Constructor<TabPattern> & T {
+  return mixinSelected(
     mixinUniqueId(
     mixinLifecycle(
-    mixinDisabled((base || class { } as Constructor<TabStub>))))) as any) {
-    constructor(...args: any[]) { super(...args); }
-  } as Constructor<TabPattern> & T;
+    mixinDisabled(
+    createMixinBase<T, TabStub>(base)))));
 }

--- a/src/lib/patterns/tab.ts
+++ b/src/lib/patterns/tab.ts
@@ -33,7 +33,7 @@ export interface TabPattern extends HasLifecycle, CanBeDisabled, HasId, CanBeSel
 // structure of `TabPattern`.
 
 /** Mixin that augments the given class with the behaviors for an `tab`. */
-export function mixinTab<T extends Constructor<object>>(base?: T): Constructor<TabPattern> & T {
+export function mixinTab<T extends Constructor>(base?: T): Constructor<TabPattern> & T {
   return class extends (
     mixinSelected(
     mixinUniqueId(

--- a/src/lib/patterns/tablist.ts
+++ b/src/lib/patterns/tablist.ts
@@ -13,21 +13,23 @@ import {
   HasActiveDescendant,
   HasId,
   HasItems,
-  HasKeySchemes, HasLifecycle,
+  HasKeySchemes,
+  HasLifecycle,
   HasOrientation,
   HasSelectedDescendant,
 } from '../behaviors/behavior-interfaces';
 import {
   mixinActiveDescendant,
   mixinBidi,
-  mixinDisabled, mixinLifecycle,
-  mixinOrientation,
+  mixinDisabled,
+  mixinLifecycle,
   mixinSelectedDescendant,
   mixinUniqueId,
 } from '../behaviors/behavior-mixins';
 import {KeyScheme} from '../key_schemes/keyscheme';
 import {ListNavigationKeyScheme} from '../key_schemes/list-navigation';
 import {ListSelectionKeyScheme} from '../key_schemes/list-selection';
+import {listboxKeySchemes} from './listbox';
 import {TabPattern} from './tab';
 
 
@@ -71,23 +73,32 @@ export interface TabListPattern extends
 // abstract stub class prevents TypeScript from recognizing that the mixins applied satisfy the
 // structure of `TabListPattern`.
 
+export function mixinTabListKeyScheme<T extends Constructor>(base: T): Constructor<HasKeySchemes<TabListPattern>> & T {
+  return class extends base implements HasKeySchemes<TabListPattern> {
+    getKeySchemes(): KeyScheme<TabListPattern>[] {
+      return listboxKeySchemes;
+    }
+
+    constructor(...args: any[]) { super(...args); }
+  };
+}
+
+// We don't use `mixinOrientation` because we want to default to horizontal
+export function mixinTabListOrientation<T extends Constructor>(base: T): Constructor<HasOrientation> & T {
+  return class extends base implements HasOrientation {
+    isHorizontal: boolean = true;
+    constructor(...args: any[]) { super(...args); }
+  }
+}
+
 /** Mixes the common behaviors of a ListBox onto a class */
 export function mixinTabList<T extends Constructor>(base?: T): Constructor<TabListPattern> & T {
-  return class extends (
+  return mixinTabListKeyScheme(
+    mixinTabListOrientation(
     mixinSelectedDescendant(
     mixinActiveDescendant(
     mixinBidi(
     mixinLifecycle(
     mixinDisabled(
-    mixinUniqueId((base || class { }) as Constructor<TabListStub>)))))) as any) {
-
-    // We don't use `mixinOrientation` because we want to default to horizontal
-    isHorizontal: boolean = true;
-
-    getKeySchemes(): KeyScheme<TabListPattern>[] {
-      return tablistKeySchemes;
-    }
-
-    constructor(...args: any[]) { super(...args); }
-  } as Constructor<TabListPattern> & T;
+    mixinUniqueId((base || class {}) as T & Constructor<TabListStub>))))))));
 }

--- a/src/lib/patterns/tablist.ts
+++ b/src/lib/patterns/tablist.ts
@@ -9,6 +9,7 @@ import {
   AffectedByRtl,
   CanBeDisabled,
   CanBeFocused,
+  ConcreteOrAbstractConstructor,
   Constructor,
   HasActiveDescendant,
   HasId,
@@ -19,6 +20,7 @@ import {
   HasSelectedDescendant,
 } from '../behaviors/behavior-interfaces';
 import {
+  createMixinBase,
   mixinActiveDescendant,
   mixinBidi,
   mixinDisabled,
@@ -67,12 +69,6 @@ export interface TabListPattern extends
     HasActiveDescendant<TabPattern>,
     HasSelectedDescendant<TabPattern> { }
 
-// Note: the `as Constructor<TabListStub>` cast below exists to enforce that downstream classes that
-// apply this mixin are still required to implement any abstract members on the stub class.
-// The casts for `as Constructor<TabListPattern> & T` and `as any` exist because the precense of the
-// abstract stub class prevents TypeScript from recognizing that the mixins applied satisfy the
-// structure of `TabListPattern`.
-
 export function mixinTabListKeyScheme<T extends Constructor>(base: T): Constructor<HasKeySchemes<TabListPattern>> & T {
   return class extends base implements HasKeySchemes<TabListPattern> {
     getKeySchemes(): KeyScheme<TabListPattern>[] {
@@ -92,7 +88,7 @@ export function mixinTabListOrientation<T extends Constructor>(base: T): Constru
 }
 
 /** Mixes the common behaviors of a ListBox onto a class */
-export function mixinTabList<T extends Constructor>(base?: T): Constructor<TabListPattern> & T {
+export function mixinTabList<T extends ConcreteOrAbstractConstructor>(base?: T): Constructor<TabListPattern> & T {
   return mixinTabListKeyScheme(
     mixinTabListOrientation(
     mixinSelectedDescendant(
@@ -100,5 +96,6 @@ export function mixinTabList<T extends Constructor>(base?: T): Constructor<TabLi
     mixinBidi(
     mixinLifecycle(
     mixinDisabled(
-    mixinUniqueId((base || class {}) as T & Constructor<TabListStub>))))))));
+    mixinUniqueId(
+    createMixinBase<T, TabListStub>(base)))))))));
 }

--- a/src/lib/patterns/tablist.ts
+++ b/src/lib/patterns/tablist.ts
@@ -72,8 +72,7 @@ export interface TabListPattern extends
 // structure of `TabListPattern`.
 
 /** Mixes the common behaviors of a ListBox onto a class */
-export function mixinTabList<T extends Constructor<object>>(base?: T):
-    Constructor<TabListPattern> & T {
+export function mixinTabList<T extends Constructor>(base?: T): Constructor<TabListPattern> & T {
   return class extends (
     mixinSelectedDescendant(
     mixinActiveDescendant(


### PR DESCRIPTION
Alternative to https://github.com/jelbourn/componentcore/pull/2, this gets rid of most of the casting and doesn't require using `infer`. Also allows `mixinListbox` to take an abstract class